### PR TITLE
Unfat devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,9 +20,7 @@
                 "timonwong.shellcheck",
                 
                 // QOL
-                "streetsidesoftware.code-spell-checker",
-                "GitHub.vscode-pull-request-github",
-                "GitHub.vscode-github-actions"
+                "streetsidesoftware.code-spell-checker"
             ]
         }
     },


### PR DESCRIPTION
removes github specifc extensions from devcontainer (currently just forwarding them from host seems to be the better option)