### PR TITLE
fix linter warning that are not highlighted

### DIFF
--- a/anilist/search.go
+++ b/anilist/search.go
@@ -2,6 +2,7 @@ package anilist
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -53,7 +54,12 @@ func GetByID(id int) (*Manga, error) {
 
 	// send request
 	log.Info("Sending request to Anilist")
-	req, err := http.NewRequest(http.MethodPost, "https://graphql.anilist.co", bytes.NewBuffer(jsonBody))
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"https://graphql.anilist.co",
+		bytes.NewBuffer(jsonBody),
+	)
 	if err != nil {
 		log.Error(err)
 		return nil, err
@@ -131,7 +137,12 @@ func SearchByName(name string) ([]*Manga, error) {
 
 	// send request
 	log.Info("Sending request to Anilist")
-	req, err := http.NewRequest(http.MethodPost, "https://graphql.anilist.co", bytes.NewBuffer(jsonBody))
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"https://graphql.anilist.co",
+		bytes.NewBuffer(jsonBody),
+	)
 	if err != nil {
 		log.Error(err)
 		return nil, err

--- a/anilist/search.go
+++ b/anilist/search.go
@@ -62,11 +62,15 @@ func GetByID(id int) (*Manga, error) {
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := network.Client.Do(req)
-
 	if err != nil {
 		log.Error(err)
 		return nil, err
 	}
+
+	defer func() {
+		// naked return used to return error from defer
+		err = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		log.Error("Anilist returned status code " + strconv.Itoa(resp.StatusCode))
@@ -136,12 +140,16 @@ func SearchByName(name string) ([]*Manga, error) {
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := network.Client.Do(req)
-
 	if err != nil {
 		log.Error(err)
 		_ = failCacher.Set(name, true)
 		return nil, err
 	}
+
+	defer func() {
+		// naked return used to return error from defer
+		err = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		log.Error("Anilist returned status code " + strconv.Itoa(resp.StatusCode))

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -265,7 +265,7 @@ var configResetCmd = &cobra.Command{
 	Short: "Reset the config key to default",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if !cmd.Flags().Changed("key") && !cmd.Flags().Changed("all") {
-			handleErr(fmt.Errorf("either --key or --all must be set"))
+			handleErr(errors.New("either --key or --all must be set"))
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -151,11 +151,11 @@ var configSetCmd = &cobra.Command{
 			v = value
 		}
 
+		var errType viper.ConfigFileNotFoundError
 		viper.Set(key, v)
-		switch err := viper.WriteConfig(); err.(type) {
-		case viper.ConfigFileNotFoundError:
+		if err := viper.WriteConfig(); errors.As(err, &errType) {
 			handleErr(viper.SafeWriteConfig())
-		default:
+		} else {
 			handleErr(err)
 		}
 
@@ -284,10 +284,10 @@ var configResetCmd = &cobra.Command{
 			viper.Set(key, config.Default[key].Value)
 		}
 
-		switch err := viper.WriteConfig(); err.(type) {
-		case viper.ConfigFileNotFoundError:
+		var errType viper.ConfigFileNotFoundError
+		if err := viper.WriteConfig(); errors.As(err, &errType) {
 			handleErr(viper.SafeWriteConfig())
-		default:
+		} else {
 			handleErr(err)
 		}
 

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 
 	"github.com/amonull/rengal/color"
 	"github.com/amonull/rengal/config"

--- a/cmd/integration.go
+++ b/cmd/integration.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -55,16 +56,16 @@ See https://github.com/metafates/mangal/wiki/Anilist-Integration for more inform
 				return
 			}
 
+			var errType viper.ConfigFileNotFoundError
 			viper.Set(key.AnilistEnable, response)
 			err = viper.WriteConfig()
 			if err != nil {
-				switch err.(type) {
-				case viper.ConfigFileNotFoundError:
+				if errors.As(err, &errType) {
 					err = viper.SafeWriteConfig()
 					handleErr(err)
-				default:
-					handleErr(err)
+				} else {
 					log.Error(err)
+					handleErr(err)
 				}
 			}
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,14 +26,14 @@ func Setup() error {
 	setDefaults()
 	setPaths()
 
+	var errType viper.ConfigFileNotFoundError
 	err := viper.ReadInConfig()
 
 	if err != nil {
-		switch err.(type) {
-		case viper.ConfigFileNotFoundError:
+		if errors.As(err, &errType) {
 			// Use defaults then
 			return nil
-		default:
+		} else {
 			return err
 		}
 	}

--- a/config/default.go
+++ b/config/default.go
@@ -51,7 +51,7 @@ var prettyTemplate = lo.Must(template.New("pretty").Funcs(template.FuncMap{
 	"purple": style.Fg(color.Purple),
 	"blue":   style.Fg(color.Blue),
 	"cyan":   style.Fg(color.Cyan),
-	"value":  func(k string) any { return viper.Get(k) },
+	"value":  viper.Get,
 	"hl": func(v any) string {
 		switch value := v.(type) {
 		case bool:
@@ -111,19 +111,6 @@ func (f *Field) typeName() string {
 		return "unknown"
 	}
 }
-
-// Pretty format field as string for further cli output
-//func (f *Field) Pretty() string {
-//	return fmt.Sprintf(
-//		`%s
-//%s: %s = %s
-//`,
-//		style.Faint(f.Description),
-//		style.Fg(color.Purple)(f.Key),
-//		style.Fg(color.Yellow)(f.typeName()),
-//		style.Fg(color.Cyan)(fmt.Sprintf("%v", viper.Get(f.Key))),
-//	)
-//}
 
 // defaults contains all default values for the config.
 // It must contain all fields defined in the constant package.

--- a/downloader/download.go
+++ b/downloader/download.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/spf13/viper"
 
@@ -94,7 +95,7 @@ func downloadPages(chapter *source.Chapter, progress func(string)) ([]*source.Pa
 	if err != nil {
 		return nil, err
 	}
-	log.Info("found " + fmt.Sprintf("%d", len(pages)) + " pages")
+	log.Info("found " + strconv.Itoa(len(pages)) + " pages")
 
 	err = chapter.DownloadPages(false, progress)
 	if err != nil {

--- a/installer/api.go
+++ b/installer/api.go
@@ -2,6 +2,7 @@ package installer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,7 +23,7 @@ type githubFilesCollector struct {
 
 func (g *githubFilesCollector) collect() error {
 	if g.user == "" || g.repo == "" || g.branch == "" {
-		return fmt.Errorf("user, repo and branch must be set")
+		return errors.New("user, repo and branch must be set")
 	}
 
 	if len(g.Files) > 0 {

--- a/installer/scraper.go
+++ b/installer/scraper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -53,7 +54,7 @@ func (s *Scraper) download() error {
 	}
 
 	if s.URL == "" {
-		return fmt.Errorf("url must be set")
+		return errors.New("url must be set")
 	}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, s.URL, nil)

--- a/installer/scraper.go
+++ b/installer/scraper.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -54,7 +55,12 @@ func (s *Scraper) download() error {
 		return fmt.Errorf("url must be set")
 	}
 
-	res, err := http.Get(s.URL)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, s.URL, nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/installer/scraper.go
+++ b/installer/scraper.go
@@ -59,6 +59,11 @@ func (s *Scraper) download() error {
 		return err
 	}
 
+	defer func() {
+		// naked return used to return error from defer
+		err = res.Body.Close()
+	}()
+
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to get %s: %s", s.URL, res.Status)
 	}

--- a/installer/scraper.go
+++ b/installer/scraper.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/amonull/rengal/filesystem"
+	"github.com/amonull/rengal/network"
 	"github.com/amonull/rengal/where"
 )
 
@@ -60,7 +61,7 @@ func (s *Scraper) download() error {
 		return err
 	}
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := network.Client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/integration/anilist/login.go
+++ b/integration/anilist/login.go
@@ -2,6 +2,7 @@ package anilist
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -47,7 +48,12 @@ func (a *Anilist) login() error {
 
 	// create request
 	log.Info("Sending login request to Anilist")
-	req, err := http.NewRequest(http.MethodPost, "https://anilist.co/api/v2/oauth/token", bytes.NewBuffer(jsonBody))
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"https://anilist.co/api/v2/oauth/token",
+		bytes.NewBuffer(jsonBody),
+	)
 	if err != nil {
 		log.Error(err)
 		return err

--- a/integration/anilist/login.go
+++ b/integration/anilist/login.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -19,17 +20,17 @@ func (a *Anilist) login() error {
 	log.Info("Logging in to Anilist")
 
 	if a.id() == "" {
-		e := fmt.Errorf("no ID set")
+		e := errors.New("no ID set")
 		log.Error(e)
 		return e
 	}
 	if a.secret() == "" {
-		e := fmt.Errorf("no secret set")
+		e := errors.New("no secret set")
 		log.Error(e)
 		return e
 	}
 	if a.code() == "" {
-		e := fmt.Errorf("no code set")
+		e := errors.New("no code set")
 		log.Error(e)
 		return e
 	}

--- a/integration/anilist/login.go
+++ b/integration/anilist/login.go
@@ -59,12 +59,15 @@ func (a *Anilist) login() error {
 
 	// send request
 	resp, err := network.Client.Do(req)
-
-	// check for error
 	if err != nil {
 		log.Error(err)
 		return err
 	}
+
+	defer func() {
+		// naked return used to return error from defer
+		err = resp.Body.Close()
+	}()
 
 	// check response code
 	if resp.StatusCode != http.StatusOK {

--- a/integration/anilist/mark.go
+++ b/integration/anilist/mark.go
@@ -76,6 +76,11 @@ func (a *Anilist) MarkRead(chapter *source.Chapter) error {
 		return err
 	}
 
+	defer func() {
+		// naked return used to return error from defer
+		err = resp.Body.Close()
+	}()
+
 	if resp.StatusCode != http.StatusOK {
 		log.Info("Request failed with status code: " + strconv.Itoa(resp.StatusCode))
 		return fmt.Errorf("invalid response code %d", resp.StatusCode)

--- a/integration/anilist/mark.go
+++ b/integration/anilist/mark.go
@@ -2,6 +2,7 @@ package anilist
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -52,7 +53,8 @@ func (a *Anilist) MarkRead(chapter *source.Chapter) error {
 	}
 
 	// make request
-	req, err := http.NewRequest(
+	req, err := http.NewRequestWithContext(
+		context.Background(),
 		http.MethodPost,
 		"https://graphql.anilist.co",
 		bytes.NewBuffer(jsonBody),

--- a/mini/mini.go
+++ b/mini/mini.go
@@ -89,10 +89,8 @@ func Run(options *Options) error {
 		truncateAt = w
 	}
 
-	var err error
-
 	for {
-		if m.handleState() != nil {
+		if err := m.handleState(); err != nil {
 			return err
 		}
 	}

--- a/mini/states.go
+++ b/mini/states.go
@@ -3,12 +3,12 @@ package mini
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/samber/lo"
 	"github.com/spf13/viper"
-	"golang.org/x/exp/slices"
 
 	"github.com/amonull/rengal/downloader"
 	"github.com/amonull/rengal/history"

--- a/mini/states.go
+++ b/mini/states.go
@@ -378,8 +378,7 @@ func (m *mini) handleHistorySelectState() error {
 		return err
 	}
 
-	switch b {
-	case quit:
+	if b == quit {
 		m.newState(quitState)
 		return nil
 	}

--- a/provider/custom/loader.go
+++ b/provider/custom/loader.go
@@ -44,10 +44,7 @@ func LoadSource(path string, validate bool) (source.Source, error) {
 		}
 	}
 
-	luaSource, err := newLuaSource(name, state)
-	if err != nil {
-		return nil, err
-	}
+	luaSource := newLuaSource(name, state)
 
 	return luaSource, nil
 }

--- a/provider/custom/source.go
+++ b/provider/custom/source.go
@@ -25,7 +25,7 @@ func (s *luaSource) ID() string {
 	return IDfromName(s.name)
 }
 
-func newLuaSource(name string, state *lua.LState) (*luaSource, error) {
+func newLuaSource(name string, state *lua.LState) *luaSource {
 	s := &luaSource{
 		name:  name,
 		state: state,
@@ -38,9 +38,10 @@ func newLuaSource(name string, state *lua.LState) (*luaSource, error) {
 	s.cache.mangas = newCacher[[]*source.Manga](cacheName("mangas"))
 	s.cache.chapters = newCacher[[]*source.Chapter](cacheName("chapters"))
 
-	return s, nil
+	return s
 }
 
+//nolint:unparam // lua.LValue ret is infact not being used ever but it will be kept to not break functionality that might depend on black magic
 func (s *luaSource) call(fn string, ret lua.LValueType, args ...lua.LValue) (lua.LValue, error) {
 	err := s.state.CallByParam(lua.P{
 		Fn:      s.state.GetGlobal(fn),

--- a/provider/custom/translator.go
+++ b/provider/custom/translator.go
@@ -28,15 +28,16 @@ func translate(
 		)
 
 		val := table.RawGetString(field)
-		if val.Type() == lua.LTNil {
+		switch val.Type() {
+		case lua.LTNil:
 			if required {
-				err = fmt.Errorf(`field of "%s" is required`, field)
+				err = fmt.Errorf("field of \"%s\" is required", field)
 			} else {
 				err = handle(default_)
 			}
-		} else if val.Type() != type_ {
-			err = fmt.Errorf(`field of "%s" must be of type %s`, field, type_)
-		} else {
+		case type_:
+			err = fmt.Errorf("field of \"%s\" must be of type %s", field, type_)
+		default:
 			err = handle(val.String())
 		}
 

--- a/provider/mangadex/chapters.go
+++ b/provider/mangadex/chapters.go
@@ -3,11 +3,11 @@ package mangadex
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"strconv"
 
 	"github.com/darylhjd/mangodex"
 	"github.com/spf13/viper"
-	"golang.org/x/exp/slices"
 
 	"github.com/amonull/rengal/key"
 	"github.com/amonull/rengal/source"

--- a/query/suggest.go
+++ b/query/suggest.go
@@ -1,11 +1,12 @@
 package query
 
 import (
+	"slices"
+
 	"github.com/lithammer/fuzzysearch/fuzzy"
 	"github.com/samber/lo"
 	"github.com/samber/mo"
 	"github.com/spf13/viper"
-	"golang.org/x/exp/slices"
 
 	"github.com/amonull/rengal/key"
 	"github.com/amonull/rengal/util"

--- a/source/chapter.go
+++ b/source/chapter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -195,9 +196,9 @@ func (c *Chapter) formattedName() (name string) {
 	for variable, value := range map[string]string{
 		"manga":          c.Manga.Name,
 		"chapter":        c.Name,
-		"index":          fmt.Sprintf("%d", c.Index),
+		"index":          strconv.FormatUint(uint64(c.Index), 16),
 		"padded-index":   fmt.Sprintf("%04d", c.Index),
-		"chapters-count": fmt.Sprintf("%d", len(c.Manga.Chapters)),
+		"chapters-count": strconv.Itoa(len(c.Manga.Chapters)),
 		"volume":         c.Volume,
 		"source":         sourceName,
 	} {

--- a/source/manga.go
+++ b/source/manga.go
@@ -354,7 +354,7 @@ func (m *Manga) populateMetadataStaff(manga *anilist.Manga) {
 
 func (m *Manga) populateMetadataUrl(manga *anilist.Manga) {
 	// Anilist & Myanimelist + external
-	urls := make([]string, 2+len(manga.External))
+	urls := make([]string, 0, 2+len(manga.External))
 	urls[0] = manga.SiteURL
 	for i, e := range manga.External {
 		urls[i+1] = e.URL

--- a/source/manga.go
+++ b/source/manga.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -131,7 +132,7 @@ func (m *Manga) GetCover() (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("no cover found")
+	return "", errors.New("no cover found")
 }
 
 func (m *Manga) DownloadCover(overwrite bool, path string, progress func(string)) error {

--- a/source/manga.go
+++ b/source/manga.go
@@ -354,7 +354,6 @@ func (m *Manga) populateMetadataStaff(manga *anilist.Manga) {
 
 func (m *Manga) populateMetadataUrl(manga *anilist.Manga) {
 	// Anilist & Myanimelist + external
-	//nolint:makezero // downloads break when starting from 0
 	urls := make([]string, 2+len(manga.External))
 	urls[0] = manga.SiteURL
 	for i, e := range manga.External {
@@ -365,6 +364,7 @@ func (m *Manga) populateMetadataUrl(manga *anilist.Manga) {
 		return url != ""
 	})
 
+	//nolint:makezero // when urls slice is init to len 0 downloads break
 	urls = append(urls, fmt.Sprintf("https://myanimelist.net/manga/%d", manga.IDMal))
 
 	m.Metadata.URLs = urls

--- a/source/manga.go
+++ b/source/manga.go
@@ -332,10 +332,10 @@ func (m *Manga) peekPath() string {
 }
 
 func (m *Manga) populateMetadataStaff(manga *anilist.Manga) {
-	m.Metadata.Staff.Story = make([]string, 0, 0)
-	m.Metadata.Staff.Art = make([]string, 0, 0)
-	m.Metadata.Staff.Translation = make([]string, 0, 0)
-	m.Metadata.Staff.Lettering = make([]string, 0, 0)
+	m.Metadata.Staff.Story = make([]string, 0)
+	m.Metadata.Staff.Art = make([]string, 0)
+	m.Metadata.Staff.Translation = make([]string, 0)
+	m.Metadata.Staff.Lettering = make([]string, 0)
 
 	for _, staff := range manga.Staff.Edges {
 		role := strings.ToLower(staff.Role)

--- a/source/manga.go
+++ b/source/manga.go
@@ -354,7 +354,8 @@ func (m *Manga) populateMetadataStaff(manga *anilist.Manga) {
 
 func (m *Manga) populateMetadataUrl(manga *anilist.Manga) {
 	// Anilist & Myanimelist + external
-	urls := make([]string, 0, 2+len(manga.External))
+	//nolint:makezero // downloads break when starting from 0
+	urls := make([]string, 2+len(manga.External))
 	urls[0] = manga.SiteURL
 	for i, e := range manga.External {
 		urls[i+1] = e.URL

--- a/source/manga_test.go
+++ b/source/manga_test.go
@@ -1,7 +1,6 @@
 package source
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -86,7 +85,7 @@ func TestManga_Path(t *testing.T) {
 						So(lo.Must(filesystem.Api().IsDir(path)), ShouldBeTrue)
 
 						Convey("It should be a temp directory", func() {
-							isTemp := lo.Must(filesystem.Api().Exists(filepath.Join(os.TempDir(), filepath.Base(path))))
+							isTemp := lo.Must(filesystem.Api().Exists(filepath.Join(t.TempDir(), filepath.Base(path))))
 							So(isTemp, ShouldBeTrue)
 						})
 					})

--- a/source/page.go
+++ b/source/page.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	_ "image/gif"
@@ -122,7 +123,7 @@ func (p *Page) Source() Source {
 }
 
 func (p *Page) request() (*http.Request, error) {
-	req, err := http.NewRequest(http.MethodGet, p.URL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, p.URL, nil)
 	if err != nil {
 		log.Error(err)
 		return nil, err

--- a/source/page.go
+++ b/source/page.go
@@ -50,7 +50,10 @@ func (p *Page) Download() error {
 		return err
 	}
 
-	defer util.Ignore(resp.Body.Close)
+	defer func() {
+		// naked return used to return error from defer
+		err = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		err = errors.New("http error: " + resp.Status)

--- a/tui/bubble.go
+++ b/tui/bubble.go
@@ -223,7 +223,6 @@ func newBubble() *statefulBubble {
 			listC.Styles.Title = titleStyle
 		}
 
-		//listC.StatusMessageLifetime = time.Second * 5
 		listC.StatusMessageLifetime = time.Hour * 999 // forever
 
 		return listC

--- a/tui/bubble.go
+++ b/tui/bubble.go
@@ -207,9 +207,9 @@ func newBubble() *statefulBubble {
 			BorderForeground(lipgloss.Color("5")).
 			Foreground(lipgloss.Color("5")).
 			Padding(0, 0, 0, 1)
-		delegate.Styles.NormalTitle = delegate.Styles.NormalTitle.Copy().Foreground(lipgloss.Color("7"))
+		delegate.Styles.NormalTitle = delegate.Styles.NormalTitle.Foreground(lipgloss.Color("7"))
 
-		delegate.Styles.SelectedDesc = delegate.Styles.SelectedTitle.Copy()
+		delegate.Styles.SelectedDesc = delegate.Styles.SelectedTitle
 
 		listC := list.New([]list.Item{}, delegate, 0, 0)
 		listC.KeyMap = bubble.keymap.forList()

--- a/tui/bubble.go
+++ b/tui/bubble.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"slices"
 	"strings"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/samber/mo"
 	"github.com/spf13/viper"
-	"golang.org/x/exp/slices"
 
 	"github.com/amonull/rengal/anilist"
 	"github.com/amonull/rengal/color"

--- a/tui/bubble.go
+++ b/tui/bubble.go
@@ -160,6 +160,7 @@ func (b *statefulBubble) startLoading() tea.Cmd {
 	return tea.Batch(b.mangasC.StartSpinner(), b.chaptersC.StartSpinner())
 }
 
+//nolint:unparam // 3 methods calling stopLoading relies on nil returns and seems like it was added with intention to change in the future
 func (b *statefulBubble) stopLoading() tea.Cmd {
 	b.loading = false
 	b.mangasC.StopSpinner()

--- a/tui/handlers.go
+++ b/tui/handlers.go
@@ -2,13 +2,13 @@ package tui
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/viper"
-	"golang.org/x/exp/slices"
 
 	"github.com/amonull/rengal/anilist"
 	"github.com/amonull/rengal/color"

--- a/tui/item.go
+++ b/tui/item.go
@@ -40,7 +40,6 @@ func (t *listItem) Title() (title string) {
 	}
 
 	if title != "" && t.marked {
-		//title = fmt.Sprintf("%s %s", title, icon.Get(icon.Mark))
 		title = fmt.Sprintf("%s %s", title, t.getMark())
 	}
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -12,16 +12,17 @@ type Options struct {
 func Run(options *Options) error {
 	bubble := newBubble()
 
-	if options.Install {
+	switch {
+	case options.Install:
 		bubble.newState(scrapersInstallState)
-	} else if options.Continue {
+	case options.Continue:
 		_, err := bubble.loadHistory()
 		if err != nil {
 			return err
 		}
 
 		bubble.newState(historyState)
-	} else {
+	default:
 		bubble.newState(sourcesState)
 	}
 

--- a/tui/update.go
+++ b/tui/update.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -11,7 +12,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/samber/mo"
 	"github.com/spf13/viper"
-	"golang.org/x/exp/slices"
 
 	"github.com/amonull/rengal/anilist"
 	"github.com/amonull/rengal/color"

--- a/tui/update.go
+++ b/tui/update.go
@@ -47,6 +47,7 @@ func (b *statefulBubble) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return tea.Batch(cmd, l.NewStatusMessage(""))
 			}
 
+			//nolint:exhaustive // seems to be handled in below in second switch
 			switch b.state {
 			case searchState:
 				b.inputC.SetValue("")

--- a/tui/update.go
+++ b/tui/update.go
@@ -144,22 +144,21 @@ func (b *statefulBubble) updateScrapersInstall(msg tea.Msg) (tea.Model, tea.Cmd)
 		return b, tea.Batch(b.startLoading(), b.loadScrapers(), b.waitForScrapersLoaded())
 	}
 
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch {
-		case b.scrapersInstallC.FilterState() == list.Filtering:
-			break
-		case key.Matches(msg, b.keymap.openURL):
+	// msg := must be left here otherwise the scoping of the casting fucks up
+	if msg, ok := msg.(tea.KeyMsg); ok && b.scrapersInstallC.FilterState() != list.Filtering {
+		if key.Matches(msg, b.keymap.selectOne, b.keymap.confirm) {
+			scraper := b.scrapersInstallC.SelectedItem().(*listItem).internal.(*installer.Scraper)
+			b.newState(loadingState)
+			return b, tea.Batch(b.startLoading(), b.installScraper(scraper), b.waitForScraperInstallation())
+		}
+
+		if key.Matches(msg, b.keymap.openURL) {
 			url := b.scrapersInstallC.SelectedItem().(*listItem).internal.(*installer.Scraper).GithubURL()
 			err := open.Run(url)
 			if err != nil {
 				b.lastError = err
 				b.newState(errorState)
 			}
-		case key.Matches(msg, b.keymap.selectOne, b.keymap.confirm):
-			scraper := b.scrapersInstallC.SelectedItem().(*listItem).internal.(*installer.Scraper)
-			b.newState(loadingState)
-			return b, tea.Batch(b.startLoading(), b.installScraper(scraper), b.waitForScraperInstallation())
 		}
 	}
 
@@ -175,8 +174,7 @@ func (b *statefulBubble) updateLoading(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch {
-		case key.Matches(msg, b.keymap.back):
+		if key.Matches(msg, b.keymap.back) {
 			b.previousState()
 		}
 	case []*anilist.Manga:
@@ -339,11 +337,9 @@ func (b *statefulBubble) updateHistory(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (b *statefulBubble) updateSources(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
+	//nolint:nestif // ignoring all linter warning on ui elements see -> https://github.com/amonull/rengal/pull/25#issuecomment-2925515691
+	if msg, ok := msg.(tea.KeyMsg); ok && b.sourcesC.FilterState() != list.Filtering {
 		switch {
-		case b.sourcesC.FilterState() == list.Filtering:
-			break
 		case key.Matches(msg, b.keymap.selectAll):
 			for _, item := range b.sourcesC.Items() {
 				item := item.(*listItem)
@@ -380,7 +376,11 @@ func (b *statefulBubble) updateSources(msg tea.Msg) (tea.Model, tea.Cmd) {
 			defer b.newState(loadingState)
 
 			if len(b.selectedProviders) == 0 {
-				return b, tea.Batch(b.startLoading(), b.loadSources([]*provider.Provider{item.internal.(*provider.Provider)}), b.waitForSourcesLoaded())
+				return b, tea.Batch(
+					b.startLoading(),
+					b.loadSources([]*provider.Provider{item.internal.(*provider.Provider)}),
+					b.waitForSourcesLoaded(),
+				)
 			}
 
 			return b, tea.Batch(b.startLoading(), b.loadSources(lo.Keys(b.selectedProviders)), b.waitForSourcesLoaded())
@@ -394,15 +394,15 @@ func (b *statefulBubble) updateSources(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (b *statefulBubble) updateSearch(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch {
-		case key.Matches(msg, b.keymap.confirm) && b.inputC.Value() != "":
+	if msg, ok := msg.(tea.KeyMsg); ok {
+		if key.Matches(msg, b.keymap.confirm) && b.inputC.Value() != "" {
 			b.startLoading()
 			b.newState(loadingState)
 			go query.Remember(b.inputC.Value(), 1)
 			return b, tea.Batch(b.searchManga(b.inputC.Value()), b.waitForMangas(), b.spinnerC.Tick)
-		case key.Matches(msg, b.keymap.acceptSearchSuggestion) && b.searchSuggestion.IsPresent():
+		}
+
+		if key.Matches(msg, b.keymap.acceptSearchSuggestion) && b.searchSuggestion.IsPresent() {
 			b.inputC.SetValue(b.searchSuggestion.MustGet())
 			b.searchSuggestion = mo.None[string]()
 			b.inputC.SetCursor(len(b.inputC.Value()))
@@ -595,8 +595,7 @@ func (b *statefulBubble) updateChapters(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (b *statefulBubble) updateAnilistSelect(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
+	if msg, ok := msg.(tea.KeyMsg); ok {
 		switch {
 		case b.anilistC.FilterState() == list.Filtering:
 			break
@@ -623,7 +622,9 @@ func (b *statefulBubble) updateAnilistSelect(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			b.previousState()
-			cmd = b.chaptersC.NewStatusMessage(fmt.Sprintf(`Linked to %s %s`, style.Fg(color.Orange)(manga.Name()), style.Faint(manga.SiteURL)))
+			cmd = b.chaptersC.NewStatusMessage(
+				fmt.Sprintf(`Linked to %s %s`, style.Fg(color.Orange)(manga.Name()), style.Faint(manga.SiteURL)),
+			)
 			return b, cmd
 		}
 	}
@@ -635,8 +636,7 @@ func (b *statefulBubble) updateAnilistSelect(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (b *statefulBubble) updateConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
+	if msg, ok := msg.(tea.KeyMsg); ok {
 		switch {
 		case key.Matches(msg, b.keymap.quit):
 			return b, tea.Quit
@@ -650,7 +650,12 @@ func (b *statefulBubble) updateConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				b.chaptersToDownload.Push(chapter)
 			}
 			b.newState(downloadState)
-			return b, tea.Batch(b.startLoading(), b.downloadChapter(b.chaptersToDownload.Pop()), b.waitForChapterDownload(), b.progressC.SetPercent(0))
+			return b, tea.Batch(
+				b.startLoading(),
+				b.downloadChapter(b.chaptersToDownload.Pop()),
+				b.waitForChapterDownload(),
+				b.progressC.SetPercent(0),
+			)
 		case key.Matches(msg, b.keymap.back):
 			b.previousState()
 		}
@@ -662,8 +667,7 @@ func (b *statefulBubble) updateConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (b *statefulBubble) updateRead(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
-	switch msg.(type) {
-	case struct{}:
+	if _, ok := msg.(struct{}); ok {
 		b.stopLoading()
 		b.previousState()
 	}
@@ -704,8 +708,7 @@ func (b *statefulBubble) updateDownload(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (b *statefulBubble) updateDownloadDone(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
+	if msg, ok := msg.(tea.KeyMsg); ok {
 		switch {
 		case key.Matches(msg, b.keymap.quit):
 			return b, tea.Quit
@@ -730,7 +733,12 @@ func (b *statefulBubble) updateDownloadDone(msg tea.Msg) (tea.Model, tea.Cmd) {
 			b.failedChapters = make([]*source.Chapter, 0)
 			b.succededChapters = make([]*source.Chapter, 0)
 			b.newState(downloadState)
-			return b, tea.Batch(b.startLoading(), b.downloadChapter(b.chaptersToDownload.Pop()), b.waitForChapterDownload(), b.progressC.SetPercent(0))
+			return b, tea.Batch(
+				b.startLoading(),
+				b.downloadChapter(b.chaptersToDownload.Pop()),
+				b.waitForChapterDownload(),
+				b.progressC.SetPercent(0),
+			)
 		}
 	}
 
@@ -740,12 +748,8 @@ func (b *statefulBubble) updateDownloadDone(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (b *statefulBubble) updateError(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch {
-		case key.Matches(msg, b.keymap.quit):
-			return b, tea.Quit
-		}
+	if msg, ok := msg.(tea.KeyMsg); ok && key.Matches(msg, b.keymap.quit) {
+		return b, tea.Quit
 	}
 
 	return b, cmd

--- a/tui/view.go
+++ b/tui/view.go
@@ -248,6 +248,7 @@ var (
 	paddingStyle          = lipgloss.NewStyle().Padding(1, 2)
 )
 
+//nolint:unparam // addHelp always recieves true (but that might change so not removed)
 func (b *statefulBubble) renderLines(addHelp bool, lines []string) string {
 	h := len(lines)
 	l := strings.Join(lines, "\n")

--- a/update/comicinfo.go
+++ b/update/comicinfo.go
@@ -2,7 +2,7 @@ package update
 
 import (
 	"encoding/xml"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +28,7 @@ func getAnyChapterComicInfo(mangaPath string) (*source.ComicInfo, error) {
 	}
 
 	if len(cbzFiles) == 0 {
-		return nil, fmt.Errorf("no .cbz files found")
+		return nil, errors.New("no .cbz files found")
 	}
 
 	comicInfo, err := getComicInfoXML(cbzFiles[0])
@@ -41,7 +41,7 @@ func getAnyChapterComicInfo(mangaPath string) (*source.ComicInfo, error) {
 
 func getComicInfoXML(chapter string) (*source.ComicInfo, error) {
 	if !strings.HasSuffix(chapter, ".cbz") {
-		return nil, fmt.Errorf("chapter must be a .cbz file")
+		return nil, errors.New("chapter must be a .cbz file")
 	}
 
 	// open chapter as ReaderAt

--- a/update/series.go
+++ b/update/series.go
@@ -2,7 +2,7 @@ package update
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"path/filepath"
 
 	"github.com/amonull/rengal/filesystem"
@@ -18,7 +18,7 @@ func getSeriesJSON(manga string) (*source.SeriesJSON, error) {
 	}
 
 	if !exists {
-		return nil, fmt.Errorf("series.json must be present")
+		return nil, errors.New("series.json must be present")
 	}
 
 	contents, err := filesystem.Api().ReadFile(serisJSONPath)

--- a/update/update.go
+++ b/update/update.go
@@ -74,7 +74,7 @@ func prepareToUpdateComicXML(chapters []*downloadedChapter, manga *source.Manga,
 	// since we are trying to update ComicInfo.xml here, we do not care about any other formats other than FormatCBZ
 	// assuming all other formats are CBZ if first is to not run through th loop
 	// also skip if no chapters in slice
-	if len(chapters) < 0 || chapters[0].format != constant.FormatCBZ {
+	if len(chapters) < 1 || chapters[0].format != constant.FormatCBZ {
 		return
 	}
 

--- a/update/update.go
+++ b/update/update.go
@@ -42,7 +42,7 @@ func Metadata(mangaPath string) error {
 		return err
 	}
 
-	manga.Chapters = make([]*source.Chapter, 0, 0)
+	manga.Chapters = make([]*source.Chapter, 0)
 	chaptersPaths := make(map[*source.Chapter]string)
 	prepareToUpdateComicXML(chapters, manga, chaptersPaths)
 

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"golang.org/x/exp/constraints"
 	"golang.org/x/term"
 
 	"github.com/amonull/rengal/constant"
@@ -108,7 +108,7 @@ func Ignore(f func() error) {
 }
 
 // Max returns the maximum value of the given items.
-func Max[T constraints.Ordered](items ...T) (maxVal T) {
+func Max[T cmp.Ordered](items ...T) (maxVal T) {
 	for _, item := range items {
 		if item > maxVal {
 			maxVal = item
@@ -119,7 +119,7 @@ func Max[T constraints.Ordered](items ...T) (maxVal T) {
 }
 
 // Min returns the minimum value of the given items.
-func Min[T constraints.Ordered](items ...T) (minVal T) {
+func Min[T cmp.Ordered](items ...T) (minVal T) {
 	minVal = items[0]
 	for _, item := range items {
 		if item < minVal {

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,6 @@ import (
 	"github.com/metafates/gache"
 
 	"github.com/amonull/rengal/filesystem"
-	"github.com/amonull/rengal/util"
 	"github.com/amonull/rengal/where"
 )
 
@@ -37,7 +36,10 @@ func Latest() (version string, err error) {
 		return "", err
 	}
 
-	defer util.Ignore(resp.Body.Close)
+	defer func() {
+		// naked return used to return error from defer
+		err = resp.Body.Close()
+	}()
 
 	var release struct {
 		TagName string `json:"tag_name"`

--- a/version/version.go
+++ b/version/version.go
@@ -31,6 +31,7 @@ func Latest() (version string, err error) {
 		return ver, nil
 	}
 
+	//nolint:noctx // simple get request no need to httpRequest with ctx
 	resp, err := http.Get("https://api.github.com/repos/metafates/mangal/releases/latest")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
these issues are not highlighted by ides but are still issues and can be seens after running `make report`, they will either be ignored and a reasoning will be given for it or they will be fixed.

The following linter warnings will not be fixed but also wont be ignored as they are good to see but are either hard or impossible to remove or should not be removed:
- reassign
